### PR TITLE
Add Spring-based sorting application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-a
+# Sorting Application
+
+This project is a simple Maven-based Java application built with the Spring Framework 6 that showcases multiple sorting algorithms. It targets Java 11 source compatibility while running on any JDK that satisfies Spring's runtime requirements.
+
+## Features
+
+- Spring-managed sorting algorithms with a shared `Sorter` interface
+- Bubble sort, merge sort and quick sort implementations
+- A `SortingService` bean that delegates to available algorithms
+- Command-line application entry point and unit tests powered by JUnit 5
+
+> **Note:** Spring Framework 6 requires Java 17 or higher at runtime. The project is compiled for Java 11 source compatibility, so run it with a Java 17+ runtime.
+
+## Build and test
+
+Ensure Maven is installed and run:
+
+```bash
+mvn clean test
+```
+
+To run the demonstration application:
+
+```bash
+mvn -q exec:java -Dexec.mainClass=com.example.sorting.SortingApplication
+```
+
+The application will load the Spring context and print the results of the available sorting algorithms.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>sorting-app</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Sorting Application</name>
+    <description>Demonstrates multiple sorting algorithms with Spring Framework 6</description>
+
+    <properties>
+        <java.version>11</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.version>6.1.6</spring.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/sorting/SortingApplication.java
+++ b/src/main/java/com/example/sorting/SortingApplication.java
@@ -1,0 +1,27 @@
+package com.example.sorting;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import com.example.sorting.config.SortingConfig;
+import com.example.sorting.service.SortingService;
+
+/**
+ * Entry point that bootstraps the Spring context and demonstrates the algorithms.
+ */
+public class SortingApplication {
+
+    public static void main(String[] args) {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(SortingConfig.class)) {
+            SortingService sortingService = context.getBean(SortingService.class);
+
+            List<Integer> numbers = Arrays.asList(5, 3, 9, 1, 4, 8);
+            sortingService.getAvailableSorters().keySet().forEach(algorithm -> {
+                List<Integer> sorted = sortingService.sort(algorithm, numbers);
+                System.out.printf("%s sort: %s -> %s%n", algorithm, numbers, sorted);
+            });
+        }
+    }
+}

--- a/src/main/java/com/example/sorting/algorithm/BubbleSortAlgorithm.java
+++ b/src/main/java/com/example/sorting/algorithm/BubbleSortAlgorithm.java
@@ -1,0 +1,38 @@
+package com.example.sorting.algorithm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple bubble sort implementation.
+ */
+@Component
+public class BubbleSortAlgorithm implements Sorter {
+
+    @Override
+    public List<Integer> sort(List<Integer> numbers) {
+        List<Integer> result = new ArrayList<>(numbers);
+        int n = result.size();
+        boolean swapped;
+        do {
+            swapped = false;
+            for (int i = 1; i < n; i++) {
+                if (result.get(i - 1) > result.get(i)) {
+                    int temp = result.get(i);
+                    result.set(i, result.get(i - 1));
+                    result.set(i - 1, temp);
+                    swapped = true;
+                }
+            }
+            n--; // After each pass the largest value is guaranteed to be at the end.
+        } while (swapped);
+        return result;
+    }
+
+    @Override
+    public String getName() {
+        return "bubble";
+    }
+}

--- a/src/main/java/com/example/sorting/algorithm/MergeSortAlgorithm.java
+++ b/src/main/java/com/example/sorting/algorithm/MergeSortAlgorithm.java
@@ -1,0 +1,49 @@
+package com.example.sorting.algorithm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Merge sort implementation that recursively divides the list into halves.
+ */
+@Component
+public class MergeSortAlgorithm implements Sorter {
+
+    @Override
+    public List<Integer> sort(List<Integer> numbers) {
+        if (numbers.size() <= 1) {
+            return new ArrayList<>(numbers);
+        }
+        int mid = numbers.size() / 2;
+        List<Integer> left = sort(numbers.subList(0, mid));
+        List<Integer> right = sort(numbers.subList(mid, numbers.size()));
+        return merge(left, right);
+    }
+
+    private List<Integer> merge(List<Integer> left, List<Integer> right) {
+        List<Integer> merged = new ArrayList<>(left.size() + right.size());
+        int i = 0;
+        int j = 0;
+        while (i < left.size() && j < right.size()) {
+            if (left.get(i) <= right.get(j)) {
+                merged.add(left.get(i++));
+            } else {
+                merged.add(right.get(j++));
+            }
+        }
+        while (i < left.size()) {
+            merged.add(left.get(i++));
+        }
+        while (j < right.size()) {
+            merged.add(right.get(j++));
+        }
+        return merged;
+    }
+
+    @Override
+    public String getName() {
+        return "merge";
+    }
+}

--- a/src/main/java/com/example/sorting/algorithm/QuickSortAlgorithm.java
+++ b/src/main/java/com/example/sorting/algorithm/QuickSortAlgorithm.java
@@ -1,0 +1,52 @@
+package com.example.sorting.algorithm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Quick sort implementation using divide and conquer.
+ */
+@Component
+public class QuickSortAlgorithm implements Sorter {
+
+    @Override
+    public List<Integer> sort(List<Integer> numbers) {
+        List<Integer> copy = new ArrayList<>(numbers);
+        quickSort(copy, 0, copy.size() - 1);
+        return copy;
+    }
+
+    private void quickSort(List<Integer> list, int low, int high) {
+        if (low < high) {
+            int pivotIndex = partition(list, low, high);
+            quickSort(list, low, pivotIndex - 1);
+            quickSort(list, pivotIndex + 1, high);
+        }
+    }
+
+    private int partition(List<Integer> list, int low, int high) {
+        int pivot = list.get(high);
+        int i = low - 1;
+        for (int j = low; j < high; j++) {
+            if (list.get(j) <= pivot) {
+                i++;
+                swap(list, i, j);
+            }
+        }
+        swap(list, i + 1, high);
+        return i + 1;
+    }
+
+    private void swap(List<Integer> list, int i, int j) {
+        int temp = list.get(i);
+        list.set(i, list.get(j));
+        list.set(j, temp);
+    }
+
+    @Override
+    public String getName() {
+        return "quick";
+    }
+}

--- a/src/main/java/com/example/sorting/algorithm/Sorter.java
+++ b/src/main/java/com/example/sorting/algorithm/Sorter.java
@@ -1,0 +1,22 @@
+package com.example.sorting.algorithm;
+
+import java.util.List;
+
+/**
+ * Common contract for sorting algorithms operating on integer lists.
+ */
+public interface Sorter {
+
+    /**
+     * Sorts the provided list and returns a new {@link List} with the values in ascending order.
+     *
+     * @param numbers values to sort
+     * @return sorted values
+     */
+    List<Integer> sort(List<Integer> numbers);
+
+    /**
+     * @return algorithm name to expose via Spring's dependency lookup
+     */
+    String getName();
+}

--- a/src/main/java/com/example/sorting/config/SortingConfig.java
+++ b/src/main/java/com/example/sorting/config/SortingConfig.java
@@ -1,0 +1,9 @@
+package com.example.sorting.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = "com.example.sorting")
+public class SortingConfig {
+}

--- a/src/main/java/com/example/sorting/service/SortingService.java
+++ b/src/main/java/com/example/sorting/service/SortingService.java
@@ -1,0 +1,42 @@
+package com.example.sorting.service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.example.sorting.algorithm.Sorter;
+
+/**
+ * Delegates sorting requests to the algorithm beans registered in the Spring context.
+ */
+@Service
+public class SortingService {
+
+    private final Map<String, Sorter> sortersByName;
+
+    public SortingService(List<Sorter> sorters) {
+        this.sortersByName = sorters.stream()
+                .collect(Collectors.toUnmodifiableMap(
+                        sorter -> sorter.getName().toLowerCase(Locale.ROOT),
+                        sorter -> sorter));
+    }
+
+    public List<Integer> sort(String algorithm, List<Integer> numbers) {
+        return Optional.ofNullable(sortersByName.get(normalize(algorithm)))
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Unknown algorithm: " + algorithm + ". Available: " + sortersByName.keySet()))
+                .sort(numbers);
+    }
+
+    public Map<String, Sorter> getAvailableSorters() {
+        return sortersByName;
+    }
+
+    private String normalize(String algorithm) {
+        return algorithm.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/test/java/com/example/sorting/SortingServiceTest.java
+++ b/src/test/java/com/example/sorting/SortingServiceTest.java
@@ -1,0 +1,57 @@
+package com.example.sorting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import com.example.sorting.config.SortingConfig;
+import com.example.sorting.service.SortingService;
+
+class SortingServiceTest {
+
+    @Test
+    void bubbleSortOrdersNumbers() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(SortingConfig.class)) {
+            SortingService sortingService = context.getBean(SortingService.class);
+            List<Integer> result = sortingService.sort("bubble", Arrays.asList(3, 1, 2));
+            assertEquals(Arrays.asList(1, 2, 3), result);
+        }
+    }
+
+    @Test
+    void quickSortOrdersNumbers() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(SortingConfig.class)) {
+            SortingService sortingService = context.getBean(SortingService.class);
+            List<Integer> result = sortingService.sort("quick", Arrays.asList(9, 4, 7, 1));
+            assertEquals(Arrays.asList(1, 4, 7, 9), result);
+        }
+    }
+
+    @Test
+    void mergeSortOrdersNumbers() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(SortingConfig.class)) {
+            SortingService sortingService = context.getBean(SortingService.class);
+            List<Integer> result = sortingService.sort("merge", Arrays.asList(5, 2, 8, 6, 3));
+            assertEquals(Arrays.asList(2, 3, 5, 6, 8), result);
+        }
+    }
+
+    @Test
+    void unknownAlgorithmThrowsException() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(SortingConfig.class)) {
+            SortingService sortingService = context.getBean(SortingService.class);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> sortingService.sort("unknown", Arrays.asList(1, 2, 3)));
+            assertEquals("Unknown algorithm: unknown. Available: " + availableAlgorithms(sortingService), exception.getMessage());
+        }
+    }
+
+    private String availableAlgorithms(SortingService sortingService) {
+        return sortingService.getAvailableSorters().keySet().toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Maven project configured for Spring Framework 6 with Java 11 source compatibility
- implement bubble, merge, and quick sort algorithms exposed as Spring beans with a delegating service
- add a command-line entry point and JUnit tests demonstrating algorithm usage

## Testing
- mvn clean test *(fails: unable to download Maven plugins because the environment blocks network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ea7c51148332848928936176d195